### PR TITLE
docs(adr): namespace ADR handles to ADR-PPX-*

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -113,7 +113,7 @@ Battery tests validate responses beyond HTTP success:
 
 **A failure is a failure.** Do not dismiss test failures due to missing dependencies or import errors. The `.venv` contains all required test dependencies including `respx`. Always use the venv.
 
-**Unit test mocking strategy (ADR-006):**
+**Unit test mocking strategy (ADR-PPX-006):**
 - MCP tool tests → mock adapter via registry
 - Orchestration tests → mock MCP tools
 - Adapter tests → mock httpx (via `respx`)

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Instrument maturity varies by tool — stated plainly so results are weighed acc
 |------|-------|-----------|
 | **Mechanical** | `complete`, `react_step`, `list_models`, semantic validation (refusal / tool-call checks), consistency testing | Deterministic checks. No model-in-the-loop judgment; results carry authority as-is. |
 | **LLM-judged** | `judge` | An LLM scoring LLM output. Verdict-matching test cases let you qualify a judge model against known answers — do that before trusting its verdicts on unknowns. |
-| **Embedding-based (experimental)** | `calculate_drift`, `analyze_variants` / `generate_variants`, `analyze_trajectory` / `compare_trajectories` | Backed by [ADR-011](docs/adr/ADR-011-embedding-based-validation.md) (**proposed**, not accepted). Distance thresholds are uncalibrated ([#140](https://github.com/shanevcantwell/prompt-prix/issues/140)). Treat outputs as exploratory signal, not pass/fail authority. |
+| **Embedding-based (experimental)** | `calculate_drift`, `analyze_variants` / `generate_variants`, `analyze_trajectory` / `compare_trajectories` | Backed by [ADR-PPX-011](docs/adr/ADR-PPX-011-embedding-based-validation.md) (**proposed**, not accepted). Distance thresholds are uncalibrated ([#140](https://github.com/shanevcantwell/prompt-prix/issues/140)). Treat outputs as exploratory signal, not pass/fail authority. |
 
 ## Documentation
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,7 @@ prompt-prix is an MCP toolkit for multi-model testing and agentic self-improveme
 
 ## Four-Layer Architecture
 
-Per [ADR-006](adr/ADR-006-adapter-resource-ownership.md), every import in the codebase follows this strict layer model:
+Per [ADR-PPX-006](adr/ADR-PPX-006-adapter-resource-ownership.md), every import in the codebase follows this strict layer model:
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -237,7 +237,7 @@ For LAS or other MCP clients, recommended `timeout_ms`:
 When a judge model is selected, BatteryRunner uses **pipelined execution** — judge tasks are submitted eagerly as inference results complete, rather than waiting for all inference to finish first:
 
 ```
-Without pipelining (original two-phase, ADR-008):
+Without pipelining (original two-phase, ADR-PPX-008):
   Phase 1: [inference][inference][inference][inference]
   Phase 2:                                              [judge][judge][judge][judge]
 
@@ -248,7 +248,7 @@ With pipelining:
 
 The `current_model` drain guard on `ServerPool` is the enabler — judge tasks queue in the dispatcher until a server drains its inference model. When no judge model is set, `_execute_inference_phase()` runs directly with no pipelining overhead.
 
-See [ADR-008](adr/ADR-008-judge-scheduling.md) for the evolution from two-phase to pipelined scheduling.
+See [ADR-PPX-008](adr/ADR-PPX-008-judge-scheduling.md) for the evolution from two-phase to pipelined scheduling.
 
 ## ReAct Loop Execution
 
@@ -283,7 +283,7 @@ The react loop:
 | `CONSISTENT_FAIL` | ❌ | 0/N runs passed |
 | `INCONSISTENT` | 🟣 3/5 | Some runs passed, some failed |
 
-See [ADR-010](adr/ADR-010-consistency-runner.md) for rationale.
+See [ADR-PPX-010](adr/ADR-PPX-010-consistency-runner.md) for rationale.
 
 ## Semantic Validation
 
@@ -327,21 +327,21 @@ Promptfoo `assert` blocks are logged but **not evaluated** (warning emitted).
 
 ## Integration Points
 
-All inference servers must expose OpenAI-compatible endpoints (`GET /v1/models`, `POST /v1/chat/completions`). Supported: LM Studio, Ollama, vLLM, llama.cpp server, any OpenAI-compatible proxy. See [ADR-003](adr/003-openai-compatible-api.md).
+All inference servers must expose OpenAI-compatible endpoints (`GET /v1/models`, `POST /v1/chat/completions`). Supported: LM Studio, Ollama, vLLM, llama.cpp server, any OpenAI-compatible proxy. See [ADR-PPX-003](adr/ADR-PPX-003-openai-compatible-api.md).
 
 ## Architecture Decision Records
 
 | ADR | Decision |
 |-----|----------|
-| [001](adr/001-use-existing-benchmarks.md) | Use existing benchmarks (BFCL, Inspect AI) instead of custom eval schema |
-| [002](adr/002-fan-out-pattern-as-core.md) | Fan-out pattern as core architectural abstraction |
-| [003](adr/003-openai-compatible-api.md) | OpenAI-compatible API as sole integration layer |
-| [006](adr/ADR-006-adapter-resource-ownership.md) | Adapters own their resource management (ServerPool internal to LMStudioAdapter) |
-| [007](adr/ADR-007-cli-interface-layer.md) | CLI interface layer above orchestration |
-| [008](adr/ADR-008-judge-scheduling.md) | Pipelined judge scheduling for multi-GPU efficiency |
-| [009](adr/ADR-009-interactive-battery-grid.md) | Dismissible dialog for battery grid cell detail |
-| [010](adr/ADR-010-consistency-runner.md) | Multi-run consistency analysis (proposed) |
-| [011](adr/ADR-011-embedding-based-validation.md) | Embedding-based semantic validation (proposed) |
-| [012](adr/ADR-012-compare-to-battery-export.md) | Compare to Battery export pipeline (proposed) |
-| [013](adr/ADR-013-semantic-chunker-mcp-primitives.md) | Semantic-chunker MCP primitives (geometry, trajectory) |
-| [014](adr/ADR-014-mcp-ext-apps-battery-dashboard.md) | MCP protocol server — FastMCP over stdio for agent access |
+| [ADR-PPX-001](adr/ADR-PPX-001-use-existing-benchmarks.md) | Use existing benchmarks (BFCL, Inspect AI) instead of custom eval schema |
+| [ADR-PPX-002](adr/ADR-PPX-002-fan-out-pattern-as-core.md) | Fan-out pattern as core architectural abstraction |
+| [ADR-PPX-003](adr/ADR-PPX-003-openai-compatible-api.md) | OpenAI-compatible API as sole integration layer |
+| [ADR-PPX-006](adr/ADR-PPX-006-adapter-resource-ownership.md) | Adapters own their resource management (ServerPool internal to LMStudioAdapter) |
+| [ADR-PPX-007](adr/ADR-PPX-007-cli-interface-layer.md) | CLI interface layer above orchestration |
+| [ADR-PPX-008](adr/ADR-PPX-008-judge-scheduling.md) | Pipelined judge scheduling for multi-GPU efficiency |
+| [ADR-PPX-009](adr/ADR-PPX-009-interactive-battery-grid.md) | Dismissible dialog for battery grid cell detail |
+| [ADR-PPX-010](adr/ADR-PPX-010-consistency-runner.md) | Multi-run consistency analysis (proposed) |
+| [ADR-PPX-011](adr/ADR-PPX-011-embedding-based-validation.md) | Embedding-based semantic validation (proposed) |
+| [ADR-PPX-012](adr/ADR-PPX-012-compare-to-battery-export.md) | Compare to Battery export pipeline (proposed) |
+| [ADR-PPX-013](adr/ADR-PPX-013-semantic-chunker-mcp-primitives.md) | Semantic-chunker MCP primitives (geometry, trajectory) |
+| [ADR-PPX-014](adr/ADR-PPX-014-mcp-ext-apps-battery-dashboard.md) | MCP protocol server — FastMCP over stdio for agent access |

--- a/docs/adr/ADR-PPX-001-use-existing-benchmarks.md
+++ b/docs/adr/ADR-PPX-001-use-existing-benchmarks.md
@@ -1,4 +1,4 @@
-# ADR-001: Use Existing Benchmarks Instead of Custom Eval Schema
+# ADR-PPX-001: Use Existing Benchmarks Instead of Custom Eval Schema
 
 **Status**: Accepted
 **Date**: 2025-11-28

--- a/docs/adr/ADR-PPX-002-fan-out-pattern-as-core.md
+++ b/docs/adr/ADR-PPX-002-fan-out-pattern-as-core.md
@@ -1,4 +1,4 @@
-# ADR-002: Fan-Out Pattern as Core Architecture
+# ADR-PPX-002: Fan-Out Pattern as Core Architecture
 
 **Status**: Accepted
 **Date**: 2025-11-28

--- a/docs/adr/ADR-PPX-003-openai-compatible-api.md
+++ b/docs/adr/ADR-PPX-003-openai-compatible-api.md
@@ -1,4 +1,4 @@
-# ADR-003: OpenAI-Compatible API as Integration Layer
+# ADR-PPX-003: OpenAI-Compatible API as Integration Layer
 
 **Status**: Accepted
 **Date**: 2025-11-28

--- a/docs/adr/ADR-PPX-006-adapter-resource-ownership.md
+++ b/docs/adr/ADR-PPX-006-adapter-resource-ownership.md
@@ -1,8 +1,8 @@
-# ADR-006: Adapter Resource Ownership
+# ADR-PPX-006: Adapter Resource Ownership
 
 **Status**: Accepted
 **Date**: 2025-01-22
-**Supersedes**: ADR-002 (partial - resource management implications)
+**Supersedes**: ADR-PPX-002 (partial - resource management implications)
 
 ## Context
 
@@ -14,7 +14,7 @@ prompt-prix supports multiple inference backends with fundamentally different re
 | HF Inference | Rate-limited cloud API |
 | surf-mcp | Single browser session |
 
-Previous architecture placed `ServerPool` in the MCP/orchestration layer (see ADR-002's "Architecture Implications"), coupling generic orchestration to LM Studio's specific multi-server model. This blocked adding other backends.
+Previous architecture placed `ServerPool` in the MCP/orchestration layer (see ADR-PPX-002's "Architecture Implications"), coupling generic orchestration to LM Studio's specific multi-server model. This blocked adding other backends.
 
 **The core insight** (via Gemini 3.0 architectural review):
 
@@ -158,5 +158,5 @@ class BatteryRunner:
 
 - Gemini 3.0 architectural analysis (2025-01-22)
 - Previous planning docs: `harmonic-hatching-shamir.md`, `curried-painting-backus.md`
-- Implementation: #95 (Implement ADR-006 adapter resource ownership)
+- Implementation: #95 (Implement ADR-PPX-006 adapter resource ownership)
 - Related issues: #56 (HuggingFace adapter), #92 (connection error handling)

--- a/docs/adr/ADR-PPX-007-cli-interface-layer.md
+++ b/docs/adr/ADR-PPX-007-cli-interface-layer.md
@@ -1,8 +1,8 @@
-# ADR-007: CLI Interface Layer
+# ADR-PPX-007: CLI Interface Layer
 
 **Status**: Accepted
 **Date**: 2025-01-23
-**Extends**: ADR-006 (adds interface layer above orchestration)
+**Extends**: ADR-PPX-006 (adds interface layer above orchestration)
 
 ## Context
 
@@ -13,7 +13,7 @@ prompt-prix started as a Gradio UI for visual model comparison. However, manual 
 - **Scripting** — Batch runs across different benchmark files
 - **Integration** — Other tools want to invoke battery runs programmatically
 
-The existing architecture (ADR-006) cleanly separates orchestration from adapters:
+The existing architecture (ADR-PPX-006) cleanly separates orchestration from adapters:
 
 ```
 ORCHESTRATION (BatteryRunner, ComparisonSession)
@@ -50,7 +50,7 @@ prompt-prix has multiple interface options that share the same orchestration and
 └─────────────────────────────────────────────────────────────────┘
                                 │
                                 ↓
-                    [MCP → Adapter per ADR-006]
+                    [MCP → Adapter per ADR-PPX-006]
 ```
 
 ### Interface Implementations
@@ -145,6 +145,6 @@ This mirrors common patterns:
 
 ## References
 
-- ADR-006: Adapter Resource Ownership (the layer below interfaces)
+- ADR-PPX-006: Adapter Resource Ownership (the layer below interfaces)
 - Issue #99: Per-server queues for parallelism (affects both interfaces)
 - Script: `scripts/run_battery.py`

--- a/docs/adr/ADR-PPX-008-judge-scheduling.md
+++ b/docs/adr/ADR-PPX-008-judge-scheduling.md
@@ -1,4 +1,4 @@
-# ADR-008: Judge Scheduling Strategy for Multi-GPU Battery Runs
+# ADR-PPX-008: Judge Scheduling Strategy for Multi-GPU Battery Runs
 
 **Status:** Accepted (evolved to pipelined — see Addendum)
 **Related:** #111, #107, #130
@@ -147,7 +147,7 @@ Keep current architecture but add retry logic for judge timeouts.
 
 ### Why NOT Option B (Dedicated GPU)
 
-Option B would force `LMStudioAdapter` to become "Role-Aware" (test GPU vs judge GPU), leaking infrastructure configuration into the orchestration layer. This violates the layer separation established in ADR-006 and would undo the work from #110.
+Option B would force `LMStudioAdapter` to become "Role-Aware" (test GPU vs judge GPU), leaking infrastructure configuration into the orchestration layer. This violates the layer separation established in ADR-PPX-006 and would undo the work from #110.
 
 ## Implementation
 

--- a/docs/adr/ADR-PPX-009-interactive-battery-grid.md
+++ b/docs/adr/ADR-PPX-009-interactive-battery-grid.md
@@ -1,4 +1,4 @@
-# ADR-009: Interactive Battery Grid (Cell Selection)
+# ADR-PPX-009: Interactive Battery Grid (Cell Selection)
 
 **Status:** Accepted
 **Date:** 2026-01-24

--- a/docs/adr/ADR-PPX-010-consistency-runner.md
+++ b/docs/adr/ADR-PPX-010-consistency-runner.md
@@ -1,4 +1,4 @@
-# ADR-010: Consistency Runner for Multi-Run Statistical Analysis
+# ADR-PPX-010: Consistency Runner for Multi-Run Statistical Analysis
 
 ## Status
 Proposed

--- a/docs/adr/ADR-PPX-011-embedding-based-validation.md
+++ b/docs/adr/ADR-PPX-011-embedding-based-validation.md
@@ -1,9 +1,9 @@
-# ADR-011: Embedding-Based Semantic Validation
+# ADR-PPX-011: Embedding-Based Semantic Validation
 
 **Status**: Phase 1 Accepted (Drift Threshold Validator — #132)
 **Date**: 2026-01-31
 **Related**:
-- ADR-010 (ConsistencyRunner)
+- ADR-PPX-010 (ConsistencyRunner)
 - semantic-chunker MCP integration
 - ADR-CORE-056 (Sleeptime Model Tournament)
 - #132 (implementation)

--- a/docs/adr/ADR-PPX-012-compare-to-battery-export.md
+++ b/docs/adr/ADR-PPX-012-compare-to-battery-export.md
@@ -1,9 +1,9 @@
-# ADR-012: Compare to Battery Export Pipeline
+# ADR-PPX-012: Compare to Battery Export Pipeline
 
 **Status**: Proposed
 **Date**: 2026-02-01
 **Related**:
-- ADR-009 (Interactive Battery Grid)
+- ADR-PPX-009 (Interactive Battery Grid)
 - A1111 WebUI inter-tab workflow patterns
 
 ---

--- a/docs/adr/ADR-PPX-013-semantic-chunker-mcp-primitives.md
+++ b/docs/adr/ADR-PPX-013-semantic-chunker-mcp-primitives.md
@@ -1,10 +1,10 @@
-# ADR-013: Semantic-Chunker MCP Primitives
+# ADR-PPX-013: Semantic-Chunker MCP Primitives
 
 **Status**: Accepted
 **Date**: 2026-02-08
 **Related**:
-- ADR-006 (Adapter Resource Ownership)
-- ADR-011 (Embedding-Based Semantic Validation)
+- ADR-PPX-006 (Adapter Resource Ownership)
+- ADR-PPX-011 (Embedding-Based Semantic Validation)
 - LAS ADR-CORE-066 (Sleeptime Autonomous Orchestration)
 - LAS ADR-CORE-067 (Adapter Convergence — Shared Pool Architecture)
 - #148 (implementation)
@@ -30,7 +30,7 @@ prompt-prix's MCP tool surface is the evaluation contract for the broader ecosys
 
 - **LAS ADR-CORE-066** has LAS autonomously driving prompt-prix via MCP for background model evaluation, consistency batteries, and drift measurement. These tools are the programmatic surface LAS orchestrates against.
 - **LAS ADR-CORE-067** ports prompt-prix's `_ServerPool` + `_ConcurrentDispatcher` into LAS. The pool infrastructure is validated and adopted wholesale.
-- **ADR-011** envisions a `TrajectoryValidator` using `heller_score` to detect circular reasoning in model responses. Wrapping `analyze_trajectory` as an MCP primitive is the prerequisite.
+- **ADR-PPX-011** envisions a `TrajectoryValidator` using `heller_score` to detect circular reasoning in model responses. Wrapping `analyze_trajectory` as an MCP primitive is the prerequisite.
 
 These wrappers serve both internal pipelines and external agents.
 
@@ -53,7 +53,7 @@ Extract lazy-init helpers from `drift.py` into `mcp/tools/_semantic_chunker.py`.
 
 ### `generate_variants` re-implementation
 
-The semantic-chunker version hardcodes `openai.OpenAI(base_url="http://localhost:1234/v1")` with `model="local-model"`. This violates ADR-006 (adapter agnosticism) and LAS's model-at-call-time pattern (ADR-CORE-067 Phase 2).
+The semantic-chunker version hardcodes `openai.OpenAI(base_url="http://localhost:1234/v1")` with `model="local-model"`. This violates ADR-PPX-006 (adapter agnosticism) and LAS's model-at-call-time pattern (ADR-CORE-067 Phase 2).
 
 Re-implement using prompt-prix's `complete()` — same pattern as `judge.py`. Takes explicit `model_id` parameter. The `DIMENSION_PROMPTS` dict and prompt template are lifted from semantic-chunker.
 
@@ -73,7 +73,7 @@ Re-implement using prompt-prix's `complete()` — same pattern as `judge.py`. Ta
 - LAS can orchestrate all five embedding-based tools through a uniform MCP interface
 - `generate_variants` is adapter-agnostic — works with any backend prompt-prix supports
 - Single StateManager singleton eliminates redundant embedding model initialization
-- Foundation for ADR-011 validators (TrajectoryValidator, RefusalClusterValidator)
+- Foundation for ADR-PPX-011 validators (TrajectoryValidator, RefusalClusterValidator)
 
 ### Negative
 

--- a/docs/adr/ADR-PPX-014-mcp-ext-apps-battery-dashboard.md
+++ b/docs/adr/ADR-PPX-014-mcp-ext-apps-battery-dashboard.md
@@ -1,10 +1,10 @@
-# ADR-014: MCP ext-apps for Battery Dashboard
+# ADR-PPX-014: MCP ext-apps for Battery Dashboard
 
 **Status**: Deferred
 **Date**: 2026-02-09
 **Related**:
-- ADR-006 (Adapter Resource Ownership)
-- ADR-007 (CLI Interface Layer)
+- ADR-PPX-006 (Adapter Resource Ownership)
+- ADR-PPX-007 (CLI Interface Layer)
 - SEP-1865 (MCP Apps Extension)
 
 ---
@@ -110,7 +110,7 @@ iframe → Host → Server: tools/call "get_battery_status" { job_id }  (polling
 ### Near-Term Impact
 
 - None — this is a research capture, not an implementation decision
-- CLI (ADR-007) remains the primary agent interface for battery execution
+- CLI (ADR-PPX-007) remains the primary agent interface for battery execution
 - MCP server remains stateless with fine-grained tools
 - Gradio UI remains the primary human interface
 

--- a/docs/adr/completed/ADR-PPX-004-compare-to-battery-export.md
+++ b/docs/adr/completed/ADR-PPX-004-compare-to-battery-export.md
@@ -1,4 +1,4 @@
-# ADR-004: Compare to Battery Export Workflow
+# ADR-PPX-004: Compare to Battery Export Workflow
 
 ## Status
 
@@ -185,5 +185,5 @@ Add "Export with Context" option that:
 
 ## Related
 
-- ADR-001: Use existing benchmarks (BFCL format)
-- ADR-002: Fan-out pattern as core abstraction
+- ADR-PPX-001: Use existing benchmarks (BFCL format)
+- ADR-PPX-002: Fan-out pattern as core abstraction

--- a/docs/adr/completed/ADR-PPX-005-fan-out-service-layer.md
+++ b/docs/adr/completed/ADR-PPX-005-fan-out-service-layer.md
@@ -1,4 +1,4 @@
-# ADR-005: prompt-prix as Fan-Out Service Layer
+# ADR-PPX-005: prompt-prix as Fan-Out Service Layer
 
 **Status:** Exploratory (Living Document)
 **Date:** 2026-01-20

--- a/docs/adr/completed/ADR-PPX-015-CHANGELOG-development-testing.md
+++ b/docs/adr/completed/ADR-PPX-015-CHANGELOG-development-testing.md
@@ -59,16 +59,16 @@ Adapter routes to correct server based on prefix
 
 ---
 
-## 2026-01-21: ADR-006 Architecture Alignment
+## 2026-01-21: ADR-PPX-006 Architecture Alignment
 
 ### Commits
-- `6010b71` - test: ADR-006 test suite alignment
-- `e2c4a26` - refactor: Compare tab ADR-006 alignment
-- `b79ff2c` - refactor: ADR-006 Battery tab - MCP registry pattern
+- `6010b71` - test: ADR-PPX-006 test suite alignment
+- `e2c4a26` - refactor: Compare tab ADR-PPX-006 alignment
+- `b79ff2c` - refactor: ADR-PPX-006 Battery tab - MCP registry pattern
 
 ### Architecture Changes
 
-Implemented three-layer architecture per ADR-006:
+Implemented three-layer architecture per ADR-PPX-006:
 
 ```
 ORCHESTRATION (BatteryRunner, ComparisonSession)

--- a/docs/handoffs/2026-07-14-sk-mcp-judging-reintegration-gap.md
+++ b/docs/handoffs/2026-07-14-sk-mcp-judging-reintegration-gap.md
@@ -12,21 +12,21 @@ that "nv-embed-v2 anisotropy nullification is finally proven out."
 prompt-prix's embedding-judging seam is **inert, obsolete, and uncorrected** — it predates
 sk-mcp's rename *and* its control/data-plane redesign. This is a **re-integration project**,
 not a threshold tweak. Recorded as three cross-linked bugs; remediation deferred to an ADR
-(superseding ADR-011). No code changed this session by design (session just opened).
+(superseding ADR-PPX-011). No code changed this session by design (session just opened).
 
 ## The three gaps (durable: GitHub issues)
 
 - **#159** `bug` — **inert seam.** `prompt_prix/mcp/tools/drift.py:26` imports the retired
   `semantic_chunker` package (sk-mcp is now `semantic_kinematics`, v0.3.0a0). `ensure_importable()`
   → False → `calculate_drift` raises `ImportError` → runners silently skip drift on every run
-  (per #138). All ADR-011 validators are dead code since the rename.
+  (per #138). All ADR-PPX-011 validators are dead code since the rename.
 - **#160** `bug,refactor` — **obsolete mechanism.** Even with the name fixed, `drift.py` /
   `_semantic_chunker.py` directly import `mcp.commands.*` + drive a `StateManager` singleton —
   the pattern sk-mcp's current contract **forbids** (`ONE-DOOR`). sk-mcp now splits control-plane
   (9 MCP JSON-RPC tools) from data-plane (`BulkEmbedder`, `embed_corpus(items)->{id: np.ndarray}`).
-  **ADR-011 documents a vanished mechanism** (`SemanticChunkerMCP` / `sys.path.insert` +
+  **ADR-PPX-011 documents a vanished mechanism** (`SemanticChunkerMCP` / `sys.path.insert` +
   `StateManager`) → must be superseded, not patched.
-- **#161** `bug,enhancement` — **uncorrected measurement.** ADR-011 fixed thresholds
+- **#161** `bug,enhancement` — **uncorrected measurement.** ADR-PPX-011 fixed thresholds
   (0.3/0.25/0.35) and the #140 slider assume a stable cosine distribution. Raw
   `calculate_drift`/`embed_text` return **in-cone** vectors; nv-embed-v2 *preserves* the
   anisotropy cone (‖μ‖²≈0.31) that embeddinggemma's isotropy regularizer *suppresses*, so a
@@ -57,7 +57,7 @@ contrastive / z-scored track the record supports.
 ## Pointers
 
 - Consumer side: `prompt_prix/mcp/tools/drift.py`, `_semantic_chunker.py`;
-  `docs/adr/ADR-011-embedding-based-validation.md` (Phase 1 Accepted — now obsolete mechanism).
+  `docs/adr/ADR-PPX-011-embedding-based-validation.md` (Phase 1 Accepted — now obsolete mechanism).
 - Provider side: `/srv/dev/shanevcantwell/semantic-kinematics-mcp` — `docs/ARCHITECTURE.md`
   (control/data-plane split), `semantic_kinematics/embeddings/bulk.py` (`BulkEmbedder`), MCP
   tool server (`analyze_axis_alignment`, `calculate_drift`, `embed_text`).

--- a/examples/README.md
+++ b/examples/README.md
@@ -48,4 +48,4 @@ For rigorous evaluation, consider these established benchmarks:
 | [BFCL](https://github.com/ShishirPatil/gorilla) | Function calling | `pip install bfcl-eval` |
 | [Inspect AI](https://inspect.ai-safety-institute.org.uk/) | Safety evaluation | `pip install inspect-ai` |
 
-See [ADR-001](../docs/adr/001-use-existing-benchmarks.md) for rationale on using existing benchmarks rather than custom formats.
+See [ADR-PPX-001](../docs/adr/ADR-PPX-001-use-existing-benchmarks.md) for rationale on using existing benchmarks rather than custom formats.

--- a/prompt_prix/adapters/pooled_local.py
+++ b/prompt_prix/adapters/pooled_local.py
@@ -5,7 +5,7 @@ Uses local-inference-pool for multi-server slot management, manifest refresh,
 and health feedback. Works with any OpenAI-compatible backend (LM Studio,
 llama-server, vLLM, Ollama, etc.).
 
-Per ADR-006, this adapter OWNS its pool and dispatcher infrastructure.
+Per ADR-PPX-006, this adapter OWNS its pool and dispatcher infrastructure.
 Pool classes are imported from local-inference-pool (extracted per ADR-068).
 Orchestration and MCP layers only see the HostAdapter protocol interface.
 """

--- a/prompt_prix/battery.py
+++ b/prompt_prix/battery.py
@@ -1,7 +1,7 @@
 """
 Battery Engine - orchestrates benchmark test suite execution.
 
-Per ADR-006, BatteryRunner is in the ORCHESTRATION layer:
+Per ADR-PPX-006, BatteryRunner is in the ORCHESTRATION layer:
 - Defines WHAT to run (test matrix across models)
 - Controls concurrency via asyncio.Semaphore
 - Calls MCP primitives ONLY — never adapters directly
@@ -194,7 +194,7 @@ class BatteryRun(BaseModel):
     models: list[str]  # Model IDs (column labels)
     results: dict[str, RunResult] = {}  # key = f"{test_id}:{model_id}"
 
-    # Two-phase execution tracking (ADR-008)
+    # Two-phase execution tracking (ADR-PPX-008)
     phase: str = "inference"  # "inference" or "judging"
     judge_total: int = 0      # How many results need judging
     judge_completed: int = 0  # How many have been judged
@@ -288,7 +288,7 @@ class BatteryRunner:
     """
     Orchestrates battery execution.
 
-    Per ADR-006 (Orchestration Layer):
+    Per ADR-PPX-006 (Orchestration Layer):
     - Defines WHAT to run (test matrix across models)
     - Calls MCP primitives ONLY (complete_stream) — never adapters directly
     - DOES NOT know about servers, ServerPool, or ConcurrentDispatcher

--- a/prompt_prix/core.py
+++ b/prompt_prix/core.py
@@ -1,7 +1,7 @@
 """
 Core logic: comparison session management.
 
-Per ADR-006, server pool management is INTERNAL to adapters.
+Per ADR-PPX-006, server pool management is INTERNAL to adapters.
 This module contains orchestration-layer code only.
 """
 
@@ -23,7 +23,7 @@ class ComparisonSession:
     """
     Manages a multi-model comparison session.
 
-    Per ADR-006 (Orchestration Layer):
+    Per ADR-PPX-006 (Orchestration Layer):
     - Tracks conversation context per model
     - Calls MCP primitives ONLY — never adapters directly
     - DOES NOT know about servers, ServerPool, or ConcurrentDispatcher

--- a/prompt_prix/tabs/battery/handlers.py
+++ b/prompt_prix/tabs/battery/handlers.py
@@ -733,7 +733,7 @@ def export_grid_image():
 def handle_cell_select(evt: gr.SelectData) -> tuple:
     """Handle grid cell selection, return (dialog_visible, detail_content).
 
-    ADR-009: Click a cell to see response detail in dismissible dialog.
+    ADR-PPX-009: Click a cell to see response detail in dismissible dialog.
     """
     import logging
     logger = logging.getLogger(__name__)

--- a/prompt_prix/tabs/battery/ui.py
+++ b/prompt_prix/tabs/battery/ui.py
@@ -126,7 +126,7 @@ Each test needs: `id`, `user` (the prompt). Optional: `tools`, `system`, `pass_c
             elem_id="battery-grid"
         )
 
-        # Dismissible detail dialog (hidden by default, ADR-009)
+        # Dismissible detail dialog (hidden by default, ADR-PPX-009)
         with gr.Column(visible=False) as detail_dialog:
             gr.Markdown("### Response Detail")
             detail_markdown = gr.Markdown()
@@ -173,7 +173,7 @@ Each test needs: `id`, `user` (the prompt). Optional: `tools`, `system`, `pass_c
         status=battery_status,
         display_mode=battery_display_mode,
         grid=battery_grid,
-        # ADR-009: Dismissible detail dialog
+        # ADR-PPX-009: Dismissible detail dialog
         detail_dialog=detail_dialog,
         detail_markdown=detail_markdown,
         detail_close_btn=detail_close_btn,

--- a/prompt_prix/tabs/compare/handlers.py
+++ b/prompt_prix/tabs/compare/handlers.py
@@ -3,7 +3,7 @@ Compare tab event handlers.
 
 Handles interactive multi-turn model comparison.
 
-Per ADR-006, this is ORCHESTRATION layer code:
+Per ADR-PPX-006, this is ORCHESTRATION layer code:
 - Calls MCP primitives ONLY — never adapters directly
 - DOES NOT know about servers, ServerPool, or ConcurrentDispatcher
 """
@@ -90,7 +90,7 @@ def clear_session() -> tuple:
 async def send_single_prompt(prompt: str, tools_json: str = "", image_path: str = None, seed: int = None, repeat_penalty: float = None):
     """Send a single prompt to all models with streaming output.
 
-    Per ADR-006 (Orchestration Layer):
+    Per ADR-PPX-006 (Orchestration Layer):
     - Calls MCP primitives ONLY (complete_stream)
     - Uses semaphore for concurrency control
     - Adapter handles server selection internally

--- a/prompt_prix/ui.py
+++ b/prompt_prix/ui.py
@@ -258,14 +258,14 @@ def create_app() -> gr.Blocks:
             js=AUTO_DOWNLOAD_JS
         )
 
-        # ADR-009: Show dialog on cell select
+        # ADR-PPX-009: Show dialog on cell select
         battery.grid.select(
             fn=battery_handlers.handle_cell_select,
             inputs=[],
             outputs=[battery.detail_dialog, battery.detail_markdown]
         )
 
-        # ADR-009: Hide dialog on close button
+        # ADR-PPX-009: Hide dialog on close button
         battery.detail_close_btn.click(
             fn=lambda: gr.update(visible=False),
             inputs=[],

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -2,9 +2,9 @@
 Architecture enforcement tests.
 
 These tests verify the Orchestration -> Adapter -> Provider layering is respected.
-Per ADR-006, adapters own their resource management (ServerPool is internal to LMStudioAdapter).
+Per ADR-PPX-006, adapters own their resource management (ServerPool is internal to LMStudioAdapter).
 
-See: docs/adr/006-adapter-resource-ownership.md
+See: docs/adr/ADR-PPX-006-adapter-resource-ownership.md
 """
 import ast
 from pathlib import Path
@@ -69,7 +69,7 @@ class TestLayerBoundaries:
 
 
 class TestServerPoolEncapsulation:
-    """Verify ServerPool is encapsulated inside adapters per ADR-006."""
+    """Verify ServerPool is encapsulated inside adapters per ADR-PPX-006."""
 
     def test_mcp_complete_does_not_accept_pool_parameter(self):
         """MCP complete must NOT accept pool - adapter owns resource management."""
@@ -79,7 +79,7 @@ class TestServerPoolEncapsulation:
 
         params = list(inspect.signature(complete).parameters.keys())
         assert "pool" not in params, (
-            f"complete accepts 'pool' parameter - violates ADR-006. "
+            f"complete accepts 'pool' parameter - violates ADR-PPX-006. "
             f"Adapter should own ServerPool internally. Current params: {params}"
         )
 
@@ -91,7 +91,7 @@ class TestServerPoolEncapsulation:
 
         params = list(inspect.signature(complete_stream).parameters.keys())
         assert "pool" not in params, (
-            f"complete_stream accepts 'pool' parameter - violates ADR-006. "
+            f"complete_stream accepts 'pool' parameter - violates ADR-PPX-006. "
             f"Adapter should own ServerPool internally. Current params: {params}"
         )
 
@@ -112,7 +112,7 @@ class TestServerPoolEncapsulation:
 
         if violations:
             pytest.fail(
-                f"ServerPool imported outside adapters/ - violates ADR-006:\n"
+                f"ServerPool imported outside adapters/ - violates ADR-PPX-006:\n"
                 + "\n".join(violations)
             )
 

--- a/tests/test_battery.py
+++ b/tests/test_battery.py
@@ -1,6 +1,6 @@
 """Tests for battery feature (benchmark test suite execution).
 
-Per ADR-006: BatteryRunner is orchestration layer. Tests mock MCP tools, not HTTP.
+Per ADR-PPX-006: BatteryRunner is orchestration layer. Tests mock MCP tools, not HTTP.
 """
 
 import asyncio
@@ -434,7 +434,7 @@ class TestBatteryRun:
 class TestBatteryRunner:
     """Tests for BatteryRunner orchestrator.
 
-    Per ADR-006: BatteryRunner is orchestration layer - it calls MCP tools,
+    Per ADR-PPX-006: BatteryRunner is orchestration layer - it calls MCP tools,
     doesn't know about servers or adapters. Tests mock the MCP layer.
     """
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,6 +1,6 @@
 """Tests for prompt_prix.core module.
 
-Per ADR-006: Orchestration tests mock MCP tools.
+Per ADR-PPX-006: Orchestration tests mock MCP tools.
 ServerPool and stream_completion tests are deleted - those are now internal to adapters.
 """
 
@@ -32,7 +32,7 @@ def mock_adapter():
 class TestComparisonSession:
     """Tests for ComparisonSession class.
 
-    Per ADR-006, ComparisonSession is orchestration layer:
+    Per ADR-PPX-006, ComparisonSession is orchestration layer:
     - Calls MCP primitives (complete_stream)
     - Does NOT know about ServerPool
     """

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -1,7 +1,7 @@
 """Tests for drift-based validation in battery and consistency runners.
 
 Tests mock the drift calculation (no embedding server needed for unit tests).
-Per ADR-006: orchestration tests mock MCP tools.
+Per ADR-PPX-006: orchestration tests mock MCP tools.
 """
 
 import asyncio

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,6 @@
 """Tests for prompt_prix.main module.
 
-Per ADR-006: Orchestration tests mock MCP tools, not adapters or ServerPool.
+Per ADR-PPX-006: Orchestration tests mock MCP tools, not adapters or ServerPool.
 """
 
 import pytest

--- a/tests/test_mcp_complete.py
+++ b/tests/test_mcp_complete.py
@@ -1,6 +1,6 @@
 """Tests for prompt_prix.mcp.tools.complete module.
 
-Per ADR-006: Mock at layer boundaries - MCP tests mock the adapter interface.
+Per ADR-PPX-006: Mock at layer boundaries - MCP tests mock the adapter interface.
 """
 
 import pytest

--- a/tests/test_mcp_judge.py
+++ b/tests/test_mcp_judge.py
@@ -1,6 +1,6 @@
 """Tests for prompt_prix.mcp.tools.judge module.
 
-Per ADR-006: Mock at layer boundaries - MCP tests mock the adapter interface.
+Per ADR-PPX-006: Mock at layer boundaries - MCP tests mock the adapter interface.
 """
 
 import pytest

--- a/tests/test_mcp_list_models.py
+++ b/tests/test_mcp_list_models.py
@@ -1,6 +1,6 @@
 """Tests for prompt_prix.mcp.tools.list_models module.
 
-Per ADR-006: Mock at layer boundaries - MCP tests mock the adapter interface.
+Per ADR-PPX-006: Mock at layer boundaries - MCP tests mock the adapter interface.
 """
 
 import pytest

--- a/tests/test_pooled_local_adapter.py
+++ b/tests/test_pooled_local_adapter.py
@@ -1,6 +1,6 @@
 """Tests for PooledLocalInferenceAdapter boundary conditions.
 
-Per ADR-006: ServerPool is INTERNAL to the adapter. Tests mock at httpx boundary.
+Per ADR-PPX-006: ServerPool is INTERNAL to the adapter. Tests mock at httpx boundary.
 """
 
 import asyncio

--- a/tests/test_react_step.py
+++ b/tests/test_react_step.py
@@ -1,6 +1,6 @@
 """Tests for react_step() MCP tool — single ReAct iteration primitive.
 
-Per ADR-006: MCP tool tests mock the adapter layer.
+Per ADR-PPX-006: MCP tool tests mock the adapter layer.
 react_step() calls complete_stream(), so we mock that.
 """
 


### PR DESCRIPTION
## Summary

Namespaces all bare ADR handles in `docs/adr/` per the cross-repo scheme `ADR-{CODE}-{NUM}-{slug}`, registry code `PPX`. 15 files renamed with `git mv` (history preserved), plus every unambiguous citation to those files rewritten across the repo (docs, handoffs, `.claude/CLAUDE.md`, and in-code docstrings/comments/assert-messages).

Already-namespaced `ADR-TAB-001-*` and `ADR-REFACTOR-001-*` were left untouched, as instructed.

## Branch note

The task brief flagged uncertainty over the default branch (`alpha` vs `main`). Verified live against GitHub (`git remote show origin`, `git ls-remote --heads`): the remote has **only `main`** — no `alpha` branch exists there. The local `refs/remotes/origin/HEAD` symref pointing at `alpha` was stale/orphaned local cruft, contradicted by both the live handshake and `ls-remote`. Proceeded against `main`, per the live-authoritative source. No divergence found between the `main`-taken survey and the worktree — the file set matched exactly (15 offenders, no extras/missing).

## Rename table (15 renames)

| Old | New |
|---|---|
| `docs/adr/001-use-existing-benchmarks.md` | `docs/adr/ADR-PPX-001-use-existing-benchmarks.md` |
| `docs/adr/002-fan-out-pattern-as-core.md` | `docs/adr/ADR-PPX-002-fan-out-pattern-as-core.md` |
| `docs/adr/003-openai-compatible-api.md` | `docs/adr/ADR-PPX-003-openai-compatible-api.md` |
| `docs/adr/ADR-006-adapter-resource-ownership.md` | `docs/adr/ADR-PPX-006-adapter-resource-ownership.md` |
| `docs/adr/ADR-007-cli-interface-layer.md` | `docs/adr/ADR-PPX-007-cli-interface-layer.md` |
| `docs/adr/ADR-008-judge-scheduling.md` | `docs/adr/ADR-PPX-008-judge-scheduling.md` |
| `docs/adr/ADR-009-interactive-battery-grid.md` | `docs/adr/ADR-PPX-009-interactive-battery-grid.md` |
| `docs/adr/ADR-010-consistency-runner.md` | `docs/adr/ADR-PPX-010-consistency-runner.md` |
| `docs/adr/ADR-011-embedding-based-validation.md` | `docs/adr/ADR-PPX-011-embedding-based-validation.md` |
| `docs/adr/ADR-012-compare-to-battery-export.md` | `docs/adr/ADR-PPX-012-compare-to-battery-export.md` |
| `docs/adr/ADR-013-semantic-chunker-mcp-primitives.md` | `docs/adr/ADR-PPX-013-semantic-chunker-mcp-primitives.md` |
| `docs/adr/ADR-014-mcp-ext-apps-battery-dashboard.md` | `docs/adr/ADR-PPX-014-mcp-ext-apps-battery-dashboard.md` |
| `docs/adr/completed/ADR-004-compare-to-battery-export.md` | `docs/adr/completed/ADR-PPX-004-compare-to-battery-export.md` |
| `docs/adr/completed/ADR-005-fan-out-service-layer.md` | `docs/adr/completed/ADR-PPX-005-fan-out-service-layer.md` |
| `docs/adr/completed/ADR-006-CHANGELOG-development-testing.md` | `docs/adr/completed/ADR-PPX-015-CHANGELOG-development-testing.md` **(duplicate-mint renumber, see below)** |

Untouched (already namespaced, per instructions): `docs/adr/completed/ADR-TAB-001_Regeneration_Stability_Tab.md`, `docs/adr/completed/ADR-REFACTOR-001-architecture-cleanup.md`. Also untouched: `docs/adr/completed/PROPOSAL_Prompt-Prix-ReAct-Evaluation.md` (never an ADR-numbered offender).

## Duplicate-mint decision: ADR-006 → 006 stays, CHANGELOG → 015

Two files both claimed `ADR-006`:
- `docs/adr/ADR-006-adapter-resource-ownership.md` — **10 external citations** (`docs/ARCHITECTURE.md` ×2, `ADR-007` ×4, `ADR-008` ×1, `ADR-013` ×2, `ADR-014` ×1), plus its own self-title.
- `docs/adr/completed/ADR-006-CHANGELOG-development-testing.md` — **0 external citations** (only 5 self-references inside its own body; no other file in the repo cites it by content or path).

The heavily-cited file (`adapter-resource-ownership`) keeps number **006** → `ADR-PPX-006-adapter-resource-ownership.md`. The uncited file (the CHANGELOG) is renumbered to the next free slot after accounting for all 15 offenders' target numbers (highest target = 014) → **015** → `ADR-PPX-015-CHANGELOG-development-testing.md`. The CHANGELOG's own internal `ADR-006` references (its body text describing "three-layer architecture" / "ADR-006 Architecture Alignment") were rewritten to `ADR-PPX-006`, since they unambiguously refer to the *other*, surviving ADR-006 document (the topic matches, not the CHANGELOG's own former identity).

## Citation fixes (beyond the 15 renamed files' own self-titles)

Rewrote unambiguous bare-handle citations in:
- `docs/ARCHITECTURE.md` (14 references: 4 inline prose links + a 12-row ADR table, including bare-number link text `[001]`→`[ADR-PPX-001]` etc.)
- `README.md` (1: ADR-011 embedding-validation link)
- `examples/README.md` (1: ADR-001 link)
- `.claude/CLAUDE.md` (1: ADR-006 mocking-strategy note)
- `docs/handoffs/2026-07-14-sk-mcp-judging-reintegration-gap.md` (5: all ADR-011 references)
- In-code docstrings/comments/assert-messages referencing ADR-006/008/009 (not listed as a heavy-hitter in the brief, but caught by the repo-wide sweep to keep the rigor bar — no dangling citations): `prompt_prix/battery.py`, `prompt_prix/core.py`, `prompt_prix/ui.py`, `prompt_prix/adapters/pooled_local.py`, `prompt_prix/tabs/battery/ui.py`, `prompt_prix/tabs/battery/handlers.py`, `prompt_prix/tabs/compare/handlers.py`, and 10 files under `tests/`. Also fixed a pre-existing stale path in `tests/test_architecture.py` (`docs/adr/006-adapter-resource-ownership.md`, missing the `ADR-` prefix even before this migration) → now points at the correct renamed file.

## Unresolved citations (left untouched — do not resolve unambiguously to a renamed file)

- `docs/MCP_TOOLS.md:336` — `ADR-064` (no such file anywhere in the corpus)
- `prompt_prix/adapters/pooled_local.py:9` — `ADR-068` (no such file anywhere in the corpus)
- `docs/adr/completed/ADR-REFACTOR-001-architecture-cleanup.md:5` — `ADR-073` (no such file anywhere in the corpus)
- `examples/file_categorization_drift_tests.json:31,33`, `examples/file_categorization_eval.yaml:153,156`, `examples/react_file_categorization_benchmark.json:458,461,468` — synthetic benchmark fixture content describing a *fictional* "ADR-001: Use PostgreSQL" / "ADR-002: Adopt TypeScript" (unrelated made-up decisions used as eval test data) — does not refer to this repo's real ADR-001/ADR-002

## Residue after verification (expected)

Final `grep -rInE '(^|[^-A-Za-z])ADR-[0-9]{1,4}\b' --include='*.md'` across the worktree turns up exactly one hit: the `ADR-064` reference in `docs/MCP_TOOLS.md` above (unresolved, listed). The filename scan (`find … -iregex '.*/(0[0-9]{2}|ADR-[0-9]{1,3})-.*\.md'`) returns nothing — no bare-handle filenames remain anywhere in the repo.

## Test plan

- [x] `grep -rInE '(^|[^-A-Za-z])ADR-[0-9]{1,4}\b' --include='*.md' .` → only the documented unresolved residue
- [x] Filename regex scan for bare `0NN-*.md` / `ADR-NNN-*.md` → empty
- [x] `git status`/`git diff --stat` reviewed; all 15 renames show as `R` (history preserved via `git mv`)
- [ ] Not run: `pytest` (no `.venv` provisioned in the isolated worktree; changes to `tests/*.py` are docstring/assert-message text only, no logic touched)